### PR TITLE
fix missing upi object

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ function factoryP(vpat, name, isDyanmic, ammount) {
 }
 
 function factory(vpat, name, isDyanmic, ammount) {
-    let upi = new UPI(vpat, name, isDyanmic, ammount)  
+    return new UPI(vpat, name, isDyanmic, ammount)  
 }
 
 module.exports = {


### PR DESCRIPTION
Error occurs when running Static method
 ``` TypeError: Cannot read property 'setMerchant' of undefined ```